### PR TITLE
add "alwaysSuccess" flag to allow grunt to continues on instead of drops

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ grunt.initConfig({
   protractor: {
     options: {
       configFile: "node_modules/protractor/referenceConf.js", // Default config file
+      alwaysSuccess: false, //if enabled, make sure grunt task continues on even if there are test failures. 
+                            // Useful when use with grunt watch 
       args: {
         // Arguments passed to the command
       }

--- a/tasks/protractor_runner.js
+++ b/tasks/protractor_runner.js
@@ -19,7 +19,7 @@ module.exports = function(grunt) {
 
     // Merge options onto data, with data taking precedence
     opts = grunt.util._.merge(opts, this.data);
-
+    var alwaysSuccess = 'alwaysSuccess';
     var strArgs = ["seleniumAddress", "seleniumServerJar", "seleniumPort", "baseUrl", "rootElement"];
     var listArgs = ["specs"];
     var boolArgs = ["includeStackTrace", "verbose"];
@@ -53,10 +53,16 @@ module.exports = function(grunt) {
       },
       function(error, result, code) {
         if (error) {
-          grunt.log.error(String(result));
-          grunt.fail.fatal('protractor exited with code: '+code, 3);
+          grunt.log.error(String(result));        
+          if(opts[alwaysSuccess]){
+            done();
+            done = null;
+          } else {
+            grunt.fail.fatal('protractor exited with code: '+code, 3);
+          }
         } else {
           done();
+          done = null;
         }
       }
     );


### PR DESCRIPTION
I was using grunt protractor runner with grunt watch and noticed if the tests fail, grunt just stops completely doesn't allow "watch" to run on. So I add an "alwaysSuccess" flag to allow that to happen.
