### PR TITLE
Added 'options.debug' functionality and test file.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,6 +33,7 @@ module.exports = function(grunt) {
       testTargetConfigFile: {
         configFile:"test/testConf.js"
       },
+      
       testKeepAliveOnFailedTest: {
         configFile:"test/testConf.js",
         keepAlive: true,
@@ -49,6 +50,15 @@ module.exports = function(grunt) {
             rootElement:"body",
             specs:["test/blankTest.js"],
             verbose:true
+          }
+        }
+      },
+      testDebug: {
+        configFile:"test/testConf.js",
+        debug:true,
+        options: {
+          args: {
+            specs:["test/debugTest.js"],
           }
         }
       }

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Default value: `true`
 If true, grunt process continues even if the test fails. This option is useful when using with grunt watch.
 If false, grunt process stops when the test fails.
 
+#### options.debug
+Type: `Boolean`
+Default value: `false`
+
+If true, grunt will pass 'debug' as second argument to protractor CLI to enable node CLI debugging as described in [Protractor Debugging documentation](https://github.com/angular/protractor/blob/master/docs/debugging.md).
+
 #### options.args
 Type: `Object`
 Default value: `{}`

--- a/tasks/protractor_runner.js
+++ b/tasks/protractor_runner.js
@@ -26,6 +26,10 @@ module.exports = function(grunt) {
     var boolArgs = ["includeStackTrace", "verbose"];
 
     var args = ['./node_modules/protractor/bin/protractor', opts.configFile];
+    if (!grunt.util._.isUndefined(opts.debug) && opts.debug === true){
+      args.splice(1,0,'debug');
+    }
+
     // Iterate over all supported arguments.
     strArgs.forEach(function(a) {
       if (a in opts.args) {

--- a/test/debugTest.js
+++ b/test/debugTest.js
@@ -1,0 +1,11 @@
+describe('Debugger test', function() {
+  ptor = protractor.getInstance();
+  it('should laucnh debugger and verify window.clientSideScripts loaded', function() {
+  	ptor.debugger();
+    // window.clientSideScripts should be injected on ptor.debugger()
+    ptor.executeScript("return (window.clientSideScripts !== undefined)").then(function (result, err){
+  	  require("grunt").log.writeln("testing that clientSideScripts exist:" + result);		
+  	  expect(result).toEqual(true);
+    });
+  });
+});


### PR DESCRIPTION
Wanted to enable protractor debug state as described [in the Protractor docs](https://github.com/angular/protractor/blob/master/docs/debugging.md).

Desired command: `protractor debug [config-file.js]`

This PR makes it available via: `options.debug = [Boolean] Default value: false`. 

I added ./test/debugTest.js and a new test task to Gruntfile. This will launch the debugger. You'll need to enter `c` <enter> a few times to progress through a few breakpoints, but there's a jasmine test that should eventually validate the debugger was successfully loaded. And then when done pretty control-c 2x to exit the debugger to continue test tasks.

Also, there's current a small parse error in the default protractor referenceConf.js that may give you an error when running debug mode first time. Need to manually fix that until they patch it upstream. https://github.com/angular/protractor/pull/179
