### PR TITLE
Removed maximum protractor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "peerDependencies": {
     "grunt": "~0.4.1",
-    "protractor": ">=0.10.0-0 <0.12.0-0"
+    "protractor": ">=0.10.0-0"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
There seems little point in forcing a maximum version of protractor, it just means everything breaks when a new version of protractor is released.  This will reduce the level of maintenance required to keep this plugin functioning.

Realistically we can expect any changes to be backwards compatible at first with outdated methods deprecated for at least a version before being removed.
