### PR TITLE
Add Sauce Labs configuration keys to strArgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Supported arguments are below.
 * params `object`: Param object to be passed to the test as browser.params
 * chromeDriver `string`: Location of chrome driver overridng the property in config file
 * chromeOnly `boolean`: Bypass Selenium for Chrome only testing
+* sauceUser `string`: Username for a SauceLabs account
+* sauceKey `string`: Access Key for a SauceLabs account
 
 ## Tests
 

--- a/tasks/protractor_runner.js
+++ b/tasks/protractor_runner.js
@@ -30,7 +30,7 @@ module.exports = function(grunt) {
     grunt.verbose.writeln("Options: " + util.inspect(opts));
 
     var keepAlive = opts['keepAlive'];
-    var strArgs = ["seleniumAddress", "seleniumServerJar", "seleniumPort", "baseUrl", "rootElement", "browser", "chromeDriver", "chromeOnly"];
+    var strArgs = ["seleniumAddress", "seleniumServerJar", "seleniumPort", "baseUrl", "rootElement", "browser", "chromeDriver", "chromeOnly", "sauceUser", "sauceKey"];
     var listArgs = ["specs"];
     var boolArgs = ["includeStackTrace", "verbose"];
 


### PR DESCRIPTION
Right now you can't do something as follows because Sauce Labs configuration
options are not passed to protractor:

```
options: {
  keepAlive: false,
  args: {
    sauceUser: 'myuser',
    sauceKey: 'mykey',
    baseUrl: 'http://www.google.com',
    params: { ... }
  }
}
```
