### PR TITLE
Fixed protractor bin path for non-local node_modules

### DIFF
--- a/tasks/protractor_runner.js
+++ b/tasks/protractor_runner.js
@@ -9,6 +9,7 @@
 'use strict';
 
 var util = require('util');
+var path = require('path');
 
 module.exports = function(grunt) {
 
@@ -34,7 +35,11 @@ module.exports = function(grunt) {
     var listArgs = ["specs"];
     var boolArgs = ["includeStackTrace", "verbose"];
 
-    var args = ['./node_modules/protractor/bin/protractor', opts.configFile];
+    // '.../node_modules/protractor/lib/protractor.js'
+    var protractorMainPath = require.resolve('protractor');
+    // '.../node_modules/protractor/bin/protractor'
+    var protractorBinPath = path.resolve(protractorMainPath, '../../bin/protractor');
+    var args = [protractorBinPath, opts.configFile];
     if (opts.noColor){
       args.push('--no-jasmineNodeOpts.showColors');
     }


### PR DESCRIPTION
The current configuration doesn't work if the "protractor" Node module is installed anywhere other than the "node_modules" folder that is sibling to the closest self-or-ancestor Gruntfile.

Conversely, this patch allows "protractor" to be installed globally or in ancestral "node_modules" folders.
