### PR TITLE
Allow configuration from the gruntfile.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "protractor": ">=0.14.0-0 <1.0.0"
+    "protractor": ">=0.14.0-0 <1.0.0",
+    "lodash": "~2.4.1"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.0",

--- a/tasks/protractor_runner.js
+++ b/tasks/protractor_runner.js
@@ -10,6 +10,7 @@
 
 var util = require('util');
 var path = require('path');
+var _ = require('lodash');
 
 module.exports = function(grunt) {
 
@@ -30,6 +31,9 @@ module.exports = function(grunt) {
       debug: false,
       args: {}
     });
+
+    // Merge options onto data, with data taking precedence.
+    opts.args = _.merge(opts.args, this.data);
 
     // configFile is a special property which need not to be in options{} object.
     if (!grunt.util._.isUndefined(this.data.configFile)) {


### PR DESCRIPTION
This pull is to allow users to enter configuration directly in the gruntfile. Currently, if there is a configFile specified, parameters specified in the gruntfile.js are not taken into account.

example : 
_gruntfile.js_

```
// Configuration to be run (and then tested).
    protractor: {
      options: {
        keepAlive: false
      },
      test1: {
        baseUrl: 'http://localhost:4100/app/',
        configFile:"test/protractor-conf.js"
      },
      test2: {
        baseUrl: 'http://localhost:8000/app/',
        configFile:"test/protractor-conf.js"
      }
    }
```

This is already available with grunt-karma-runner and would be great to have available in grunt-protractor-runner.
