### PR TITLE
Added support for multiCapabilities object and splitTestsBetweenCapabilities boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Supported arguments are below.
 * sauceUser `string`: Username for a SauceLabs account
 * sauceKey `string`: Access Key for a SauceLabs account
 * capabilities `object`: Capabilities object to be passed to the test, e.g. browserName, platform and version
+* multiCapabilities `object`: multiCapabilities object to be passed to the test.  Protractor will run tests in parallel against each set of capabilities.
+* splitTestsBetweenCapabilities `boolean`: If true, will split different test files over different instances of a browser resulting in a faster test throughput
 * framework `string`: Limited support for using mocha as the test framework instead of jasmine.
 * cucumberOpts `object`: Cucumber framework options object to be passed to the test, e.g. require, tags and format
 

--- a/tasks/protractor_runner.js
+++ b/tasks/protractor_runner.js
@@ -41,8 +41,8 @@ module.exports = function(grunt) {
     var keepAlive = opts['keepAlive'];
     var strArgs = ["seleniumAddress", "seleniumServerJar", "seleniumPort", "baseUrl", "rootElement", "browser", "chromeDriver", "chromeOnly", "sauceUser", "sauceKey", "framework"];
     var listArgs = ["specs"];
-    var boolArgs = ["includeStackTrace", "verbose"];
-    var objectArgs = ["params", "capabilities", "cucumberOpts"];
+    var boolArgs = ["includeStackTrace", "verbose", "splitTestsBetweenCapabilities"];
+    var objectArgs = ["params", "capabilities", "cucumberOpts", "multiCapabilities"];
 
     var args = [protractorBinPath, opts.configFile];
     if (opts.noColor){


### PR DESCRIPTION
These two parameters were fairly recently added to protractor and I'd like to be able to pass them directly into my protractor config file from the gruntfile.
