### PR TITLE
defined "options.output" to write result in a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,6 @@ Default value: `false`
 If true, protractor will not give colored output.
 If false, protractor will give colored output, as it does by default.
 
-#### options.output
-Type: `String`
-
-The file that the task should output the results to.
-
 #### options.debug
 Type: `Boolean`
 Default value: `false`
@@ -106,6 +101,12 @@ Supported arguments are below.
 * framework `string`: Limited support for using mocha as the test framework instead of jasmine.
 * cucumberOpts `object`: Cucumber framework options object to be passed to the test, e.g. require, tags and format
 * mochaOpts `object`: Mocha test framework options object to be passed
+
+#### options.output
+Type: `String`
+Default value: `false`
+
+The file that the task should output the results to.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ Default value: `false`
 If true, protractor will not give colored output.
 If false, protractor will give colored output, as it does by default.
 
+#### options.output
+Type: `String`
+
+The file that the task should output the results to.
+
 #### options.debug
 Type: `Boolean`
 Default value: `false`

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "grunt-contrib-jshint": "~0.6.0",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-nodeunit": "~0.2.0",
-    "grunt": "~0.4.1"
+    "grunt": "~0.4.1",
+    "split": "~0.3.0",
+    "through2": "~0.5.1"
   },
   "peerDependencies": {
     "grunt": "~0.4.1"


### PR DESCRIPTION
**INPUT**
sample Gruntfile.js config

```
...
        protractor: {
            options: {
                configFile: 'test/protractor/conf.js',
                args: {
                    baseUrl: 'http://localhost:18000',
                    browser: 'phantomjs'
                },
                output: 'build/artifacts/test/protractor/results.tap'
            }
        }
...
```

**OUTPUT**
sample output result
```
$ cat build/artifacts/test/protractor/results.tap
1..2
ok 1 test page should have a title in the page
ok 2 test page should have value "signedin" after clicking .authState() button
# tests 2
# pass 2
# fail 0
```