### PR TITLE
Cmd to fix "Could not find chromedriver at"

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ In case you want to use the plugin with the global installed protractor command.
 
 You need to install/update selenium webdriver for protractor.
 
-* Run `webdriver-manager update` or `node scripts/webdriver-manager-update`
+* Run `node ./node_modules/protractor/bin/webdriver-manager update`
 
 ## Release History
 


### PR DESCRIPTION
This command fixes "Could not find chromedriver at" in all platforms (win, mac, *nix). I also think that it should be added to the postinstall callback to avoid pain to future users...