### PR TITLE
Add config option to define path to the node binary file

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Supported arguments are below.
 * framework `string`: Limited support for using mocha as the test framework instead of jasmine.
 * cucumberOpts `object`: Cucumber framework options object to be passed to the test, e.g. require, tags and format
 * mochaOpts `object`: Mocha test framework options object to be passed
+* nodeBin `string`: Path to the node binary file('node' as default). Useful if node is not on the PATH. 
 
 ## Tests
 

--- a/tasks/protractor_runner.js
+++ b/tasks/protractor_runner.js
@@ -28,6 +28,7 @@ module.exports = function(grunt) {
       keepAlive: false,
       noColor: false,
       debug: false,
+      nodeBin: 'node',
       args: {}
     });
 
@@ -103,7 +104,7 @@ module.exports = function(grunt) {
     // Spawn protractor command
     var done = this.async();
     grunt.util.spawn({
-        cmd: 'node',
+        cmd: opts.nodeBin,
         args: args,
         opts: {
           stdio:'inherit'


### PR DESCRIPTION
If the node binary is not on the PATH environment variable the runner fail with errno 127 cannot find 'node'. I've added the option to customize path to the node binary file... 

The default value is the same as before.