### PR TITLE
Throw warning instead of fatal error so that grunt can still use --force with it

### DIFF
--- a/tasks/protractor_runner.js
+++ b/tasks/protractor_runner.js
@@ -115,17 +115,14 @@ module.exports = function(grunt) {
           if(code === 1 && keepAlive) {
             // Test fails but do not want to stop the grunt process.
             grunt.log.oklns("Test failed but keep the grunt process alive.");
-            done();
-            done = null;
           } else {
             // Test fails and want to stop the grunt process,
             // or protractor exited with other reason.
-            grunt.fail.fatal('protractor exited with code: '+code, 3);
+            grunt.warn('Tests failed, protractor exited with code: '+code);
           }
-        } else {
-          done();
-          done = null;
         }
+        done();
+        done = null;
       }
     );
   });


### PR DESCRIPTION
grunt.fail.fatal was preventing me to be able to force the running of protractor and get to the next task.  I could of used the keepAlive options, but the keepAlive doesn't let my build server know that something wrong happened in the test and exited with code 0.