### PR TITLE
Fixed support for object options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 tmp
 selenium
 /*.iml
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "0.12"
 before_script:
   - npm install -g grunt-cli
 before_install:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -87,7 +87,7 @@ module.exports = function(grunt) {
 
   // Whenever the "test" task is run, first clean the "tmp" dir, then run this
   // plugin's task(s), then test the result.
-  grunt.registerTask('test', ['clean', 'protractor']);
+  grunt.registerTask('test', ['clean', 'nodeunit', 'protractor']);
 
   // By default, lint and run all tests.
   grunt.registerTask('default', ['jshint', 'test']);

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If true, grunt will pass 'debug' as second argument to protractor CLI to enable 
 Type: `Object`
 Default value: `{}`
 
-Arguments passed to the command. These arguments can also be supplied via command-line too. Ex.`grunt protractor --specs=specs/some-test.js`
+Arguments passed to the command. These arguments can also be supplied via command-line too. Ex.`grunt protractor --specs=specs/some-test.js`  or for object options `grunt protractor --cucumberOpts={\"tags\":\"@quick\"}`
 Supported arguments are below.
 
 * seleniumAddress `string`: A running selenium address to use
@@ -129,6 +129,7 @@ Run `npm install` to install dependencies.
 
 Then run `grunt` or `npm test` to test the module. You will encounter these.
 
+* Runs unit and e2e tests
 * It opens chrome a couple of times without warnings or errors.
 * A test task fails but the test process keeps alive and continues to the next test tasks.
 

--- a/tasks/protractor_runner.js
+++ b/tasks/protractor_runner.js
@@ -77,6 +77,9 @@ module.exports = function(grunt) {
     // Convert [object] to --[object].key1 val1 --[object].key2 val2 ....
     objectArgs.forEach(function(a) {
       (function convert(prefix, obj, args) {
+        if (typeof obj === 'string'){
+          obj = JSON.parse(obj);
+        }
         for (var key in obj) {
           var val = obj[key];
           var type = typeof obj[key];
@@ -100,7 +103,7 @@ module.exports = function(grunt) {
             args.push(prefix+"."+key, val);
           }
         }
-      })("--" + a, opts.args[a], args);
+      })("--" + a, grunt.option(a) || opts.args[a], args);
     });
 
     grunt.verbose.writeln("Spawn node with arguments: " + args.join(" "));

--- a/test/objectArgs_test.js
+++ b/test/objectArgs_test.js
@@ -1,0 +1,20 @@
+var exec = require('child_process').execSync,
+    runnerStdOut;
+
+exports.testCucumberOpts = function (test) {
+    var cmd = 'grunt protractor --cucumberOpts={\\"tags\\":\\"@quick\\"} --verbose',
+        testDone = false;
+
+    runnerStdOut = exec(cmd)
+    if (typeof runnerStdOut === 'object'){
+        runnerStdOut = runnerStdOut.toString();
+    }
+    if (runnerStdOut.indexOf('Spawn node with arguments:') > -1 && runnerStdOut.indexOf('--cucumberOpts.tags @quick') > -1) {
+        test.ok(true, 'CucumberOpts test passed!')
+        test.done();
+    } else {
+        test.ok(false, 'Could not find cucumberOpts')
+        test.done();
+    }
+};
+


### PR DESCRIPTION
I was trying to use --cucumberOpts and it was failing.  I changed the code based on my understanding of the code.  I added a unit test and configured them to run with the Grunt test task.  I had to bump up the node version to 0.12, so my unit test would work.  Please review my changes.