### PR TITLE
Fix EINVAL error when run in git bash shell

### DIFF
--- a/tasks/protractor_runner.js
+++ b/tasks/protractor_runner.js
@@ -137,7 +137,12 @@ module.exports = function(grunt) {
           done = null;
         }
       );
-      process.stdin.pipe(child.stdin);
+      try {
+        process.stdin.pipe(child.stdin);
+      }
+      catch (e) {
+        grunt.log.debug("Non-fatal: stdin cannot be piped in this shell");
+      }
       child.stdout.pipe(process.stdout);
       child.stderr.pipe(process.stderr);
 


### PR DESCRIPTION
Piping stdin on Windows bash shell fails apparently because nodejs
officially only supports the CMD shell.  In this code the pipe is
only used as debugging aid; therefore in this case we can fail the pipe
silently and let the spawn succeed.