### PR TITLE
Append test results to output file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ Default value: `false`
 
 The file that the task should output the results to.
 
+#### options.outputOptions
+Type: `Object`
+Default value: `{}`
+
+Options for output file. For details see: [fs.createWriteStream's options](https://nodejs.org/api/fs.html#fs_fs_createwritestream_path_options)
+
 #### options.nodeBin
 Type: `String`
 Default value: `node`

--- a/tasks/protractor_runner.js
+++ b/tasks/protractor_runner.js
@@ -36,6 +36,7 @@ module.exports = function(grunt) {
       nodeBin: 'node',
       args: {},
       output: false,
+      outputOptions: {},
       webdriverManagerUpdate: false
     });
 
@@ -168,7 +169,7 @@ module.exports = function(grunt) {
             }
             callback();
           }))
-          .pipe(fs.createWriteStream(opts.output));
+          .pipe(fs.createWriteStream(opts.output, opts.outputOptions));
       }
     };
 

--- a/test/objectArgs_test.js
+++ b/test/objectArgs_test.js
@@ -5,15 +5,15 @@ exports.testCucumberOpts = function (test) {
     var cmd = 'grunt protractor:testTargetConfigFile --cucumberOpts={\\"tags\\":\\"@quick\\"} --verbose',
         testDone = false;
 
-    runnerStdOut = exec(cmd)
+    runnerStdOut = exec(cmd);
     if (typeof runnerStdOut === 'object'){
         runnerStdOut = runnerStdOut.toString();
     }
     if (runnerStdOut.indexOf('Spawn node with arguments:') > -1 && runnerStdOut.indexOf('--cucumberOpts.tags @quick') > -1) {
-        test.ok(true, 'CucumberOpts test passed!')
+        test.ok(true, 'CucumberOpts test passed!');
         test.done();
     } else {
-        test.ok(false, 'Could not find cucumberOpts')
+        test.ok(false, 'Could not find cucumberOpts');
         test.done();
     }
 };


### PR DESCRIPTION
We want to append test results to the output file. The actual output file option overrides it any time when the tests are executed. With outputOptions: { flags: 'a' } it is possible to keep the file. There are many other options available.