### PR TITLE
add webDriverProxy argument for browserstack proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Supported arguments are below.
 * mochaOpts `object`: Mocha test framework options object to be passed
 * beforeLaunch `string`: You can specify a file containing code to run once configs are read but before any environment setup. This will only run once, and before onPrepare.
 * onPrepare `string`: You can specify a file containing code to run once protractor is ready and available, and before the specs are executed. If multiple capabilities are being run, this will run once per capability.
+* webDriverProxy `string`: WebDriver proxy configuration to run remote tests
 
 #### options.output
 Type: `String`

--- a/tasks/protractor_runner.js
+++ b/tasks/protractor_runner.js
@@ -47,7 +47,7 @@ module.exports = function(grunt) {
     grunt.verbose.writeln("Options: " + util.inspect(opts));
 
     var keepAlive = opts['keepAlive'];
-    var strArgs = ["seleniumAddress", "seleniumServerJar", "seleniumPort", "baseUrl", "rootElement", "browser", "chromeDriver", "chromeOnly", "directConnect", "sauceUser", "sauceKey", "sauceSeleniumAddress", "framework", "suite", "beforeLaunch", "onPrepare"];
+    var strArgs = ["seleniumAddress", "seleniumServerJar", "seleniumPort", "baseUrl", "rootElement", "browser", "chromeDriver", "chromeOnly", "directConnect", "sauceUser", "sauceKey", "sauceSeleniumAddress", "framework", "suite", "beforeLaunch", "onPrepare", "webDriverProxy"];
     var listArgs = ["specs", "exclude"];
     var boolArgs = ["includeStackTrace", "verbose"];
     var objectArgs = ["params", "capabilities", "cucumberOpts", "mochaOpts"];


### PR DESCRIPTION
This argument was included on protractor recently as you can see here: https://github.com/angular/protractor/pull/2872

Could you please merge it and release a new version with [protractor dependency updated](https://github.com/teerapap/grunt-protractor-runner/pull/145) on npm registry?

Thank you