### PR TITLE
Pass through all grunt options to protractor

### DIFF
--- a/tasks/protractor_runner.js
+++ b/tasks/protractor_runner.js
@@ -62,17 +62,17 @@ module.exports = function(grunt) {
 
     // Iterate over all supported arguments.
     strArgs.forEach(function(a) {
-      if (a in opts.args || grunt.option(a)) {
-        args.push('--'+a, grunt.option(a) || opts.args[a]);
+      if (a in opts.args) {
+        args.push('--'+a, opts.args[a]);
       }
     });
     listArgs.forEach(function(a) {
-      if (a in opts.args || grunt.option(a)) {
-        args.push('--'+a,  grunt.option(a) || opts.args[a].join(","));
+      if (a in opts.args) {
+        args.push('--'+a, opts.args[a].join(","));
       }
     });
     boolArgs.forEach(function(a) {
-      if (a in opts.args || grunt.option(a)) {
+      if (a in opts.args) {
         args.push('--'+a);
       }
     });
@@ -110,9 +110,14 @@ module.exports = function(grunt) {
             args.push(prefix+"."+key, val);
           }
         }
-      })("--" + a, grunt.option(a) || opts.args[a], args);
+      })("--" + a, opts.args[a], args);
     });
 
+    // Pass any remaining grunt options to protractor verbatim.
+    //
+    // This allows for adding to Object-flavored arguments, and for overriding
+    // any other flavor of arguments, via the command line.
+    args = args.concat(grunt.option.flags());
 
     // Spawn protractor command
     var done = this.async();

--- a/test/objectArgs_test.js
+++ b/test/objectArgs_test.js
@@ -2,14 +2,14 @@ var exec = require('child_process').execSync,
     runnerStdOut;
 
 exports.testCucumberOpts = function (test) {
-    var cmd = 'grunt protractor:testTargetConfigFile --cucumberOpts={\\"tags\\":\\"@quick\\"} --verbose',
+    var cmd = 'grunt protractor:testTargetConfigFile --cucumberOpts.tags=@quick --verbose',
         testDone = false;
 
     runnerStdOut = exec(cmd)
     if (typeof runnerStdOut === 'object'){
         runnerStdOut = runnerStdOut.toString();
     }
-    if (runnerStdOut.indexOf('Spawn node with arguments:') > -1 && runnerStdOut.indexOf('--cucumberOpts.tags @quick') > -1) {
+    if (runnerStdOut.indexOf('Spawn node with arguments:') > -1 && runnerStdOut.indexOf('--cucumberOpts.tags=@quick') > -1) {
         test.ok(true, 'CucumberOpts test passed!')
         test.done();
     } else {
@@ -17,4 +17,3 @@ exports.testCucumberOpts = function (test) {
         test.done();
     }
 };
-


### PR DESCRIPTION
It seems odd to have to pass in object arguments as escaped json strings.

This change allows for 
1. passing in object arguments exactly as you would pass them to the protractor process.
2. overriding parts of objects via the command line, without overriding the entire object

E.g. This does not override any other `capabilities` or `cucumberOpts` you already have configured, and instead only sets these specific keys of those objects:
`grunt protractor --cucumberOpts.tags=@myTag --capabilities.tunnel-identifier=myTunnelId`