### PR TITLE
#121 and #51 - Add support for Command Line Params

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,5 @@ node_js:
 before_script:
   - npm install -g grunt-cli
 before_install:
-  - "wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -"
-  - "sudo sh -c 'echo \"deb http://dl.google.com/linux/chrome/deb/ stable main\" >> /etc/apt/sources.list.d/google.list'"
-  - "sudo apt-get update"
-  - "sudo apt-get install google-chrome-stable"
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/tasks/protractor_runner.js
+++ b/tasks/protractor_runner.js
@@ -79,8 +79,8 @@ module.exports = function(grunt) {
 
     //Add command line params support
     var commandParams = grunt.option.flags();
-    commandParams.forEach(function (a){
-      if (a.indexOf('--params') === 0){
+    commandParams.forEach(function (a) {
+      if (a.indexOf('--params') === 0) {
         args.push(a);
       }
     });

--- a/tasks/protractor_runner.js
+++ b/tasks/protractor_runner.js
@@ -79,12 +79,12 @@ module.exports = function(grunt) {
 
     //Add command line params support
     var commandParams = grunt.option.flags();
-    commandParams.forEach(function(a){
-      if (a.indexOf('--params') ==0){
+    commandParams.forEach( function (a){
+      if (a.indexOf('--params') === 0){
         args.push(a);
       }
     });
-    
+
     // Convert [object] to --[object].key1 val1 --[object].key2 val2 ....
     objectArgs.forEach(function(a) {
       (function convert(prefix, obj, args) {

--- a/tasks/protractor_runner.js
+++ b/tasks/protractor_runner.js
@@ -79,7 +79,7 @@ module.exports = function(grunt) {
 
     //Add command line params support
     var commandParams = grunt.option.flags();
-    commandParams.forEach( function (a){
+    commandParams.forEach(function (a){
       if (a.indexOf('--params') === 0){
         args.push(a);
       }

--- a/tasks/protractor_runner.js
+++ b/tasks/protractor_runner.js
@@ -77,6 +77,14 @@ module.exports = function(grunt) {
       }
     });
 
+    //Add command line params support
+    var commandParams = grunt.option.flags();
+    commandParams.forEach(function(a){
+      if (a.indexOf('--params') ==0){
+        args.push(a);
+      }
+    });
+    
     // Convert [object] to --[object].key1 val1 --[object].key2 val2 ....
     objectArgs.forEach(function(a) {
       (function convert(prefix, obj, args) {

--- a/tasks/protractor_runner.js
+++ b/tasks/protractor_runner.js
@@ -51,7 +51,9 @@ module.exports = function(grunt) {
     var objectArgs = ["params", "capabilities", "cucumberOpts", "mochaOpts"];
 
     var cmd = [protractorBinPath];
-    if (!grunt.util._.isUndefined(opts.configFile)) cmd.push(opts.configFile);
+    if (!grunt.util._.isUndefined(opts.configFile)) {
+      cmd.push(opts.configFile);
+    }
     var args = process.execArgv.concat(cmd);
     if (opts.noColor){
       args.push('--no-jasmineNodeOpts.showColors');


### PR DESCRIPTION
There are two open issues, #51 and #121, all about the same issue. This is the solution for that problem.

With this, we can do `grunt protractor --params.location=http://localhost:3030/`