### PR TITLE
Update to latest grunt version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "grunt": "~0.4.1"
   },
   "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin",

--- a/tasks/protractor_runner.js
+++ b/tasks/protractor_runner.js
@@ -51,7 +51,9 @@ module.exports = function(grunt) {
     var objectArgs = ["params", "capabilities", "cucumberOpts", "mochaOpts"];
 
     var cmd = [protractorBinPath];
-    if (!grunt.util._.isUndefined(opts.configFile)) cmd.push(opts.configFile);
+    if (!grunt.util._.isUndefined(opts.configFile)){
+      cmd.push(opts.configFile);
+    }
     var args = process.execArgv.concat(cmd);
     if (opts.noColor){
       args.push('--no-jasmineNodeOpts.showColors');


### PR DESCRIPTION
Update to latest Grunt version (currently 1.0.1) following Grunt team recommendations (http://gruntjs.com/blog/2016-04-04-grunt-1.0.0-released#peer-dependencies)
Local tests seems ok. (I've added missing curly braces for grunt task to run - I suppose this is linked to a linter task because `npm test` runs well without the fix)