### PR TITLE
override protractorMainPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,22 @@ Default value: `false`
 
 If true, `webdriver-manager update` will run and install/update selenium driver.
 
+#### options.protractorMainPath
+Type: `String`
+Default value: `node_modules/grunt-protractor-runner/node_modules/protractor`
+
+Option to point at a specific version of protractor
+
+```js
+grunt.initConfig({
+  protractor: {
+    options: {
+      protractorMainPath: require.resolve('protractor') // use my installed protractor instead of the default.
+    }
+  }
+});
+```
+
 ## Tests
 
 Run `npm install` to install dependencies.
@@ -165,10 +181,10 @@ This plugin installs `protractor` module locally as a normal dependency.
 
 In case you want to use the plugin with the global installed protractor command. You can do it with these steps below.
 
-* Remove local install protractor by `rm -rf node_modules/protractor`
 * Install `protractor` globally  with `npm install -g protractor`
 * Make sure that node can resolve the module with `require()` mechanism. See [Module loading from the global folders](http://nodejs.org/api/modules.html#modules_loading_from_the_global_folders) for more information.
 * Run `webdriver-manager update` to install/update selenium driver for global install protractor.
+* Add `protractorMainPath: require.resolve('protractor')` to your options.
 
 ### Q: Error: Could not find chromedriver at....
 

--- a/tasks/protractor_runner.js
+++ b/tasks/protractor_runner.js
@@ -18,13 +18,6 @@ module.exports = function(grunt) {
 
   grunt.registerMultiTask('protractor', 'A grunt task to run protractor.', function() {
 
-    // '.../node_modules/protractor/lib/protractor.js'
-    var protractorMainPath = require.resolve('protractor');
-    // '.../node_modules/protractor/bin/protractor'
-    var protractorBinPath = path.resolve(protractorMainPath, '../../bin/protractor');
-    // '.../node_modules/protractor/bin/webdriver-manager'
-    var webdriverManagerPath = path.resolve(protractorMainPath, '../../bin/webdriver-manager');
-
     // Merge task-specific and/or target-specific options with these defaults.
     var opts = this.options({
       keepAlive: false,
@@ -34,8 +27,14 @@ module.exports = function(grunt) {
       args: {},
       output: false,
       outputOptions: {},
-      webdriverManagerUpdate: false
+      webdriverManagerUpdate: false,
+      protractorMainPath: require.resolve('protractor')
     });
+
+    // '.../node_modules/protractor/bin/protractor'
+    var protractorBinPath = path.resolve(opts.protractorMainPath, '../../bin/protractor');
+    // '.../node_modules/protractor/bin/webdriver-manager'
+    var webdriverManagerPath = path.resolve(opts.protractorMainPath, '../../bin/webdriver-manager');
 
     // configFile is a special property which need not to be in options{} object.
     if (!grunt.util._.isUndefined(this.data.configFile)) {

--- a/test/Gruntfile.js
+++ b/test/Gruntfile.js
@@ -1,0 +1,46 @@
+/*
+ * grunt-protractor-runner
+ * https://github.com/teerapap/grunt-protractor-runner
+ *
+ * Copyright (c) 2013 Teerapap Changwichukarn
+ * Licensed under the MIT license.
+ */
+
+'use strict';
+
+var path = require('path');
+
+module.exports = function(grunt) {
+
+  grunt.initConfig({
+
+    protractor: {
+      options: {
+        keepAlive: false,
+        args: {
+          specs:["test/blankTest.js"]
+        }
+      },
+      pathOvrDefault: {
+        configFile:"./testConf.js",
+        options: {}
+      },
+      pathOvrValid: {
+        configFile:"./testConf.js",
+        options: {
+          protractorMainPath: require.resolve('protractor')
+        }
+      },
+      pathOvrInvalid: {
+        configFile:"./testConf.js",
+        options: {
+          // last two things are resolved away.
+          protractorMainPath: path.resolve('areallybad','bad','path')
+        }
+      }
+
+    }
+  });
+
+  grunt.loadTasks('../tasks');
+};

--- a/test/pathOvr_test.js
+++ b/test/pathOvr_test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var child = require('child_process'),
+    path = require('path');
+
+function exec (cmd, done) {
+  child.exec(cmd, function (err, stdout, stderr) {
+    done(err, stderr || stdout);
+  });
+}
+
+function success (str) {
+  return str.indexOf('Done, without errors.') >= 0;
+}
+
+exports.pathOvr = {
+  valid: function (test) {
+    var cmd = 'grunt --gruntfile test/Gruntfile.js protractor:pathOvrValid';
+    var result = exec(cmd, function (err, result) {
+      test.ok(err === null, 'Shouldn\'t have thrown an error');
+      test.ok(success(result), 'Protractor should run fine with a valid pointer to protractor');
+      test.done();
+    });
+  },
+  invalid: function (test) {
+    var cmd = 'grunt --gruntfile test/Gruntfile.js protractor:pathOvrInvalid';
+    var badpath = ['', 'areallybad', 'bin', 'protractor'].join('\\'+path.sep);
+    var re = new RegExp('Cannot find module .*'+badpath+'\'');
+    exec(cmd, function (err, result) {
+      test.ok(err !== null, 'Should have thrown an error');
+      test.ok(result.match(re), 'Protractor should fail because the pointer to protractor is invalid');
+      test.done();
+    });
+  }
+};


### PR DESCRIPTION
I would like to always use the protractor that I have installed, instead of the one that comes with this task.
I noticed because I'm testing protractor 4.0, and grunt-protractor-runner uses "^3.2.0".

I know that I could `rm -rf node_modules/grunt-protractor-runner/node_modules/protractor`.
But counting everyone doing that on every new install isn't  a great idea.

Instead I would like to push a pointer to protractor through the options.
Something like this:
```javascript
grunt.initConfig({
  protractor: {
    options: {
      protractorMainPath: require.resolve('protractor')
    }
  }
});
```

What do you think?
