### PR TITLE
Upgraded protractor to version 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "protractor": "^3.0.0",
+    "protractor": "^4.0.0",
     "split": "~1.0.0",
     "through2": "~2.0.0"
   },


### PR DESCRIPTION
I ran `grunt default` locally and all the tests passed.