### PR TITLE
Allow suite argument as array

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,6 +68,7 @@ module.exports = function(grunt) {
             },
             rootElement:"body",
             specs:["test/argsTest.js"],
+            suite: ['login', 'logout'],
             verbose:true
           }
         }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > A Grunt plugin for running [Protractor](https://github.com/angular/protractor) runner.
 
 ## Getting Started
-This plugin requires Grunt `~0.4.1`. 
+This plugin requires Grunt `~0.4.1`.
 
 For Protractor `3.x.x`, please use version `v3.x.x` of this plugin.
 
@@ -101,7 +101,7 @@ Supported arguments are below.
 * rootElement `string`: Element housing ng-app, if not html or body
 * specs `array`: Array of spec files to test. Ex. `["spec1.js","spec2.js"]`
 * exclude `array`: Array of files to exclude from testing. Ex. `["spec2.js"]`
-* suite `string`: Name of test suite to run
+* suite `array`: Array of suite to run. Ex. `["suite1", "suite2"]`
 * includeStackTrace `boolean`: Print stack trace on error
 * verbose `boolean`: Print full spec names
 * browser `string`: Browser name, e.g. chrome or firefox

--- a/tasks/protractor_runner.js
+++ b/tasks/protractor_runner.js
@@ -45,8 +45,8 @@ module.exports = function(grunt) {
     grunt.verbose.writeln("Options: " + util.inspect(opts));
 
     var keepAlive = opts['keepAlive'];
-    var strArgs = ["seleniumAddress", "seleniumServerJar", "seleniumPort", "baseUrl", "rootElement", "browser", "chromeDriver", "chromeOnly", "directConnect", "sauceUser", "sauceKey", "sauceSeleniumAddress", "framework", "frameworkPath", "suite", "beforeLaunch", "onPrepare", "webDriverProxy"];
-    var listArgs = ["specs", "exclude"];
+    var strArgs = ["seleniumAddress", "seleniumServerJar", "seleniumPort", "baseUrl", "rootElement", "browser", "chromeDriver", "chromeOnly", "directConnect", "sauceUser", "sauceKey", "sauceSeleniumAddress", "framework", "frameworkPath", "beforeLaunch", "onPrepare", "webDriverProxy"];
+    var listArgs = ["specs", "exclude", "suite"];
     var boolArgs = ["includeStackTrace", "verbose"];
     var objectArgs = ["params", "capabilities", "cucumberOpts", "mochaOpts"];
 

--- a/test/testConf.js
+++ b/test/testConf.js
@@ -34,6 +34,11 @@ exports.config = {
   // connect to an already running instance of selenium. This usually looks like
   seleniumAddress: null,
 
+  suites: {
+    login: 'blankTest.js',
+    logout: 'blankTest.js'
+  },
+
   // ----- What tests to run -----
   //
   // Spec patterns are relative to the location of this config.
@@ -59,7 +64,7 @@ exports.config = {
   baseUrl: 'http://localhost:8000',
 
   // Selector for the element housing the angular app - this defaults to
-  // body, but is necessary if ng-app is on a descendant of <body>  
+  // body, but is necessary if ng-app is on a descendant of <body>
   rootElement: 'body',
 
   // A callback function called once protractor is ready and available, and
@@ -72,7 +77,7 @@ exports.config = {
     //     jasmine.getEnv().addReporter(new jasmine.JUnitXmlReporter(
     //         'outputdir/', true, true));
   },
-  
+
   // ----- Options to be passed to minijasminenode -----
   jasmineNodeOpts: {
     // onComplete will be called just before the driver quits.


### PR DESCRIPTION
Solves https://github.com/teerapap/grunt-protractor-runner/issues/171

## Issue
Suite argument is string but protractor can handle multi suite to run

## Solution
Change the type of suite argument from `strAgs` to `listArgs`