### PR TITLE
Use suite configuration from opts if it hasnt beed passed by command line

### DIFF
--- a/tasks/protractor_runner.js
+++ b/tasks/protractor_runner.js
@@ -42,6 +42,11 @@ module.exports = function(grunt) {
       opts.configFile = this.data.configFile;
     }
 
+    // suite may or may not to be in options{} object, and can be overriden if passed through the command line.
+    if (!grunt.util._.isUndefined(this.data.suite)) {
+      opts.suite = this.data.suite;
+    }
+
     grunt.verbose.writeln("Options: " + util.inspect(opts));
 
     var keepAlive = opts['keepAlive'];
@@ -78,6 +83,11 @@ module.exports = function(grunt) {
         args.push('--'+a);
       }
     });
+
+    //Adds the suite configuration from opts if it hasn't been added by command line arguments
+    if (!grunt.util._.isUndefined(opts.suite) && !('suite' in opts.args || grunt.option('suite'))){
+      args.push('--suite', opts.suite);
+    }
 
     // Convert [object] to --[object].key1 val1 --[object].key2 val2 ....
     objectArgs.forEach(function(a) {


### PR DESCRIPTION
Feature request!


As a tester configuring my default test execution
I want to be able to set the "suite" attribute in the Gruntfile.js (optionally)
So that I don't have to worry about this param being passed every time by the command line using --suite



This means I can use Protractors suites feature without worrying that if in my CI or someone else runs the tests without specifying --suite it will run all suites by default...

For instance I can have this in my conf.js (protractor)
```
        suites: {
		full_regression: [
			'./nice-spec.js',
			'./interesting-spec.js',
			'./boring-spec.js',
			'./short-and-sweet-spec.js'
		],
		smoke_test: [
			'./nice-spec.js',
			'./short-and-sweet-spec.js'
		]
        }
```
And this in my Gruntfile.js
```
grunt.initConfig({
                protractor : {
			options : {
				keepAlive : true,
				configFile : 'tests/e2e/conf.js',
                                suite: 'full_regression'
			},
			singlerun : {},
			auto : {
				keepAlive : true,
				options : {
					args : {
						seleniumPort : 4444
					}
				}
			}
		}
...
});
```
When I run `grunt` it will execute ONLY full_regression suite.

And when I run `grunt --suite smoke_test` it will execute only smoke_test suite.


