### PR TITLE
bump the protractor version to stop geckodriver continuously downloading

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "protractor": "^4.0.0",
+    "protractor": "^4.0.11",
     "split": "~1.0.0",
     "through2": "~2.0.0"
   },


### PR DESCRIPTION
See https://github.com/angular/webdriver-manager/issues/127 for details on the fix, this PR pushes the protractor version to 4.0.11 which takes advantage of this fix.