### PR TITLE
Support Debugging in Node >= 8

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,7 +51,6 @@ module.exports = function(grunt) {
       testArgs1: {
         configFile:"test/testConf.js",
         options: {
-          debug: true,
           args: {
             params: {
               number: 1,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,6 +51,7 @@ module.exports = function(grunt) {
       testArgs1: {
         configFile:"test/testConf.js",
         options: {
+          debug: true,
           args: {
             params: {
               number: 1,

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ If false, protractor will give colored output, as it does by default.
 Type: `Boolean`
 Default value: `false`
 
-If true, grunt will pass 'debug' as second argument to protractor CLI to enable node CLI debugging as described in [Protractor Debugging documentation](https://github.com/angular/protractor/blob/master/docs/debugging.md).
+If true, grunt will pass debugger options to protractor CLI to enable node CLI debugging as described in [Protractor Debugging documentation](https://github.com/angular/protractor/blob/master/docs/debugging.md).
+For node >= 8 '--inspect' is passed. Otherwise 'debug'.
 
 #### options.args
 Type: `Object`

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
     "through2": "~2.0.0"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.11.3",
+    "grunt": "~0.4.1",
     "grunt-contrib-clean": "~0.7.0",
+    "grunt-contrib-jshint": "~0.11.3",
     "grunt-contrib-nodeunit": "~0.4.1",
-    "grunt": "~0.4.1"
+    "semver": "^5.4.1"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"

--- a/tasks/protractor_runner.js
+++ b/tasks/protractor_runner.js
@@ -13,6 +13,7 @@ var path = require('path');
 var fs = require('fs');
 var split = require('split');
 var through2 = require('through2');
+var semver = require('semver');
 
 module.exports = function(grunt) {
 
@@ -59,7 +60,11 @@ module.exports = function(grunt) {
       args.push('--no-jasmineNodeOpts.showColors');
     }
     if (!grunt.util._.isUndefined(opts.debug) && opts.debug === true){
-      args.splice(1,0,'debug');
+      if(semver.gte(process.versions.node, '8.0.0')){
+        args.unshift('--inspect');
+      }else{
+        args.splice(1,0,'debug');
+      }
     }
 
     // Iterate over all supported arguments.


### PR DESCRIPTION
Debug flag has changed from 'debug' to '--inspect' starting with node version 8. This change uses the correct flag, depending on the running version.
  
EDIT:
Unfortunately I did not find a way to test this flag. The approach in objectArgs_test.js seems not to work here, because the debugger output is written to early …

EDIT 2:
I just realised, that you do not run node 8 on travis. Is node 8 not officially supported?